### PR TITLE
feature: 퀴즈 목록 조회 api

### DIFF
--- a/histour-application/build.gradle
+++ b/histour-application/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+    implementation project(':histour-common')
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/histour-application/src/main/java/trible/histour/application/domain/character/CharacterService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/character/CharacterService.java
@@ -6,7 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.val;
 import trible.histour.application.port.input.CharacterUseCase;
-import trible.histour.application.port.input.dto.response.CharactersResponse;
+import trible.histour.application.port.input.dto.response.character.CharactersResponse;
 import trible.histour.application.port.output.persistence.CharacterPort;
 
 @Service

--- a/histour-application/src/main/java/trible/histour/application/domain/member/Member.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/member/Member.java
@@ -21,4 +21,8 @@ public class Member {
 	public void updateRefreshToken(String refreshToken) {
 		this.refreshToken = refreshToken;
 	}
+
+	public void updateCharacter(long characterId) {
+		this.characterId = characterId;
+	}
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/member/MemberService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/member/MemberService.java
@@ -1,18 +1,24 @@
 package trible.histour.application.domain.member;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import trible.histour.application.port.input.MemberUseCase;
 import trible.histour.application.port.output.persistence.MemberPort;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService implements MemberUseCase {
 	private final MemberPort memberPort;
 
+	@Transactional
 	@Override
-	public void registerProfile() {
-		//TODO: implementation
+	public void updateCharacter(long memberId, long characterId) {
+		val member = memberPort.findById(memberId);
+		member.updateCharacter(characterId);
+		memberPort.update(member);
 	}
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
@@ -1,15 +1,28 @@
 package trible.histour.application.domain.mission;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class MemberMission {
 	Long id;
 	long memberId;
-	long placeId;
+	long missionId;
 	@NotNull
 	MissionState state;
+
+	public MemberMission(long memberId, long missionId) {
+		this.memberId = memberId;
+		this.missionId = missionId;
+		this.state = MissionState.PROGRESS;
+	}
+
+	public boolean isCompleted() {
+		return this.state == MissionState.COMPLETE;
+	}
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
@@ -1,5 +1,7 @@
 package trible.histour.application.domain.mission;
 
+import java.time.LocalDateTime;
+
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +16,8 @@ public class MemberMission {
 	long missionId;
 	@NotNull
 	MissionState state;
+	@NotNull
+	LocalDateTime createdAt;
 
 	public MemberMission(long memberId, long missionId) {
 		this.memberId = memberId;

--- a/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/mission/MemberMission.java
@@ -1,13 +1,12 @@
 package trible.histour.application.domain.mission;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class MemberMission {
 	Long id;

--- a/histour-application/src/main/java/trible/histour/application/domain/mission/MissionService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/mission/MissionService.java
@@ -1,0 +1,63 @@
+package trible.histour.application.domain.mission;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.domain.quiz.Quiz;
+import trible.histour.application.port.input.MissionUseCase;
+import trible.histour.application.port.input.dto.response.mission.MissionsResponse;
+import trible.histour.application.port.output.persistence.MemberMissionPort;
+import trible.histour.application.port.output.persistence.MemberQuizPort;
+import trible.histour.application.port.output.persistence.MissionPort;
+import trible.histour.application.port.output.persistence.PlacePort;
+import trible.histour.application.port.output.persistence.QuizPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionService implements MissionUseCase {
+	private final MissionPort missionPort;
+	private final MemberMissionPort memberMissionPort;
+	private final QuizPort quizPort;
+	private final MemberQuizPort memberQuizPort;
+	private final PlacePort placePort;
+
+	@Override
+	public MissionsResponse getMissions(long memberId, long placeId) {
+		val place = placePort.findById(placeId);
+
+		val missions = missionPort.findAllByPlaceId(placeId);
+		val missionIds = missions.stream().map(Mission::getId).toList();
+		val memberMissions = memberMissionPort.findAllByMemberIdAndMissionIds(memberId, missionIds);
+
+		val memberMissionByMissionId = memberMissions.stream()
+			.collect(Collectors.toMap(MemberMission::getMissionId, memberMission -> memberMission));
+
+		val sortedMissions = missions.stream()
+			.sorted(Comparator.comparing((Mission mission) ->
+					memberMissionByMissionId.get(mission.getId()), // 1. MemberMission 존재하면 우선으로 정렬
+				Comparator.nullsLast(Comparator.comparing(MemberMission::getCreatedAt)))) // 2. createdAt 기준 정렬
+			.toList();
+
+		val quizzes = quizPort.findAllByMissionIds(missionIds);
+		val quizById = quizzes.stream().collect(Collectors.toMap(Quiz::getId, quiz -> quiz));
+		val quizIds = quizzes.stream().map(Quiz::getId).toList();
+		val memberQuizzes = memberQuizPort.findAllByMemberIdAndQuizIds(memberId, quizIds);
+
+		return MissionsResponse.of(
+			place,
+			sortedMissions,
+			memberMissionByMissionId,
+			quizzes.stream().collect(Collectors.groupingBy(Quiz::getMissionId)),
+			memberQuizzes.stream().collect(Collectors.groupingBy(memberQuiz -> {
+				val quiz = quizById.get(memberQuiz.getQuizId());
+				return quiz.getMissionId();
+			}))
+		);
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/domain/mission/MissionState.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/mission/MissionState.java
@@ -3,5 +3,5 @@ package trible.histour.application.domain.mission;
 public enum MissionState {
 	BEFORE,
 	PROGRESS,
-	END,
+	COMPLETE,
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/place/PlaceService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/place/PlaceService.java
@@ -1,0 +1,38 @@
+package trible.histour.application.domain.place;
+
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.domain.mission.MemberMission;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.port.input.PlaceUseCase;
+import trible.histour.application.port.input.dto.response.place.PlacesResponse;
+import trible.histour.application.port.output.persistence.MemberMissionPort;
+import trible.histour.application.port.output.persistence.MissionPort;
+import trible.histour.application.port.output.persistence.PlacePort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceService implements PlaceUseCase {
+	private final PlacePort placePort;
+	private final MissionPort missionPort;
+	private final MemberMissionPort memberMissionPort;
+
+	@Override
+	public PlacesResponse getPlaces(long memberId) {
+		val placeById = placePort.findAll().stream()
+			.collect(Collectors.toMap(Place::getId, place -> place));
+
+		val memberMissions = memberMissionPort.findAllByMemberId(memberId);
+		val missionIds = memberMissions.stream().map(MemberMission::getMissionId).toList();
+		val missionsByPlaceId = missionPort.findAllByMissionIds(missionIds).stream()
+			.collect(Collectors.groupingBy(Mission::getPlaceId));
+
+		return PlacesResponse.of(placeById, missionsByPlaceId);
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/Quiz.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/Quiz.java
@@ -12,8 +12,6 @@ public class Quiz {
 	QuizType type;
 	long missionId;
 	@NotNull
-	String content;
-	@NotNull
 	String hint;
 	@NotNull
 	String answer;

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
@@ -1,0 +1,26 @@
+package trible.histour.application.domain.quiz;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.QuizUseCase;
+import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
+import trible.histour.application.port.output.persistence.MissionPort;
+import trible.histour.application.port.output.persistence.QuizPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizService implements QuizUseCase {
+	private final QuizPort quizPort;
+	private final MissionPort missionPort;
+
+	@Override
+	public QuizzesResponse getQuizzes(long missionId) {
+		val mission = missionPort.findById(missionId);
+		val quizzes = quizPort.findAllByMissionId(missionId);
+		return QuizzesResponse.of(mission, quizzes);
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
@@ -1,14 +1,25 @@
 package trible.histour.application.domain.quiz;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import trible.histour.application.domain.mission.MemberMission;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.domain.mission.MissionType;
 import trible.histour.application.port.input.QuizUseCase;
 import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
+import trible.histour.application.port.output.persistence.MemberMissionPort;
+import trible.histour.application.port.output.persistence.MemberQuizPort;
 import trible.histour.application.port.output.persistence.MissionPort;
+import trible.histour.application.port.output.persistence.PlacePort;
 import trible.histour.application.port.output.persistence.QuizPort;
+import trible.histour.common.exception.ExceptionCode;
+import trible.histour.common.exception.HistourException;
 
 @Service
 @RequiredArgsConstructor
@@ -16,11 +27,66 @@ import trible.histour.application.port.output.persistence.QuizPort;
 public class QuizService implements QuizUseCase {
 	private final QuizPort quizPort;
 	private final MissionPort missionPort;
+	private final PlacePort placePort;
+	private final MemberMissionPort memberMissionPort;
+	private final MemberQuizPort memberQuizPort;
 
+	@Transactional
 	@Override
-	public QuizzesResponse getQuizzes(long missionId) {
+	public QuizzesResponse getQuizzes(long memberId, long missionId) {
 		val mission = missionPort.findById(missionId);
+		val missions = missionPort.findAllByPlaceId(mission.getPlaceId());
+		val missionIds = missions.stream().map(Mission::getId).toList();
+		val memberMissions = memberMissionPort.findAllByMemberIdAndMissionIds(memberId, missionIds);
+		validMemberQuiz(memberId, mission, memberMissions, missions);
+
+		memberMissions.stream()
+			.filter(memberMission -> memberMission.getMissionId() == missionId)
+			.findAny()
+			.orElseGet(() -> memberMissionPort.save(new MemberMission(memberId, missionId)));
+
 		val quizzes = quizPort.findAllByMissionId(missionId);
-		return QuizzesResponse.of(mission, quizzes);
+		val quizIds = quizzes.stream().map(Quiz::getId).toList();
+		val memberQuizzes = memberQuizPort.findAllByMemberIdAndQuizIds(memberId, quizIds);
+		return QuizzesResponse.of(mission, quizzes, memberQuizzes.size());
+	}
+
+	private void validMemberQuiz(
+		long memberId,
+		Mission mission,
+		List<MemberMission> memberMissions,
+		List<Mission> missions
+	) {
+		val completedMemberMissions = memberMissions.stream().filter(MemberMission::isCompleted).toList();
+
+		completedMemberMissions.stream()
+			.filter(it -> it.getMissionId() == mission.getId())
+			.findAny()
+			.ifPresent(it -> {
+				throw new HistourException(
+					ExceptionCode.BAD_REQUEST,
+					"이미 완료된 미션, MissionID: " + mission.getId() + ", MemberID: " + memberId);
+			});
+
+		if (mission.getType() == MissionType.NORMAL) {
+			val missionById = missions.stream().collect(Collectors.toMap(Mission::getId, it -> it));
+			completedMemberMissions.stream()
+				.filter(it -> missionById.get(it.getMissionId()).getType() == MissionType.INTRO)
+				.findAny()
+				.orElseThrow(() -> new HistourException(
+					ExceptionCode.BAD_REQUEST,
+					"Intro 미션을 수행하지 않음, MissionID: " + mission.getId() + ", MemberID: " + memberId));
+		}
+
+		if (mission.getType() == MissionType.FINAL) {
+			val place = placePort.findById(mission.getPlaceId());
+			if (completedMemberMissions.size() != place.getRequiredMissionCount() - 1) {
+				throw new HistourException(
+					ExceptionCode.BAD_REQUEST,
+					"Final 미션 전 필요한 완료 미션 개수가 부족함 ("
+						+ completedMemberMissions.size() + "/" + (place.getRequiredMissionCount() - 1)
+						+ "), MemberID: " + memberId);
+			}
+		}
 	}
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
@@ -14,7 +14,6 @@ import trible.histour.application.domain.mission.MissionType;
 import trible.histour.application.port.input.QuizUseCase;
 import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
 import trible.histour.application.port.output.persistence.MemberMissionPort;
-import trible.histour.application.port.output.persistence.MemberQuizPort;
 import trible.histour.application.port.output.persistence.MissionPort;
 import trible.histour.application.port.output.persistence.PlacePort;
 import trible.histour.application.port.output.persistence.QuizPort;
@@ -29,7 +28,6 @@ public class QuizService implements QuizUseCase {
 	private final MissionPort missionPort;
 	private final PlacePort placePort;
 	private final MemberMissionPort memberMissionPort;
-	private final MemberQuizPort memberQuizPort;
 
 	@Transactional
 	@Override
@@ -46,9 +44,7 @@ public class QuizService implements QuizUseCase {
 			.orElseGet(() -> memberMissionPort.save(new MemberMission(memberId, missionId)));
 
 		val quizzes = quizPort.findAllByMissionId(missionId);
-		val quizIds = quizzes.stream().map(Quiz::getId).toList();
-		val memberQuizzes = memberQuizPort.findAllByMemberIdAndQuizIds(memberId, quizIds);
-		return QuizzesResponse.of(mission, quizzes, memberQuizzes.size());
+		return QuizzesResponse.of(mission, quizzes);
 	}
 
 	private void validMemberQuiz(

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizType.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizType.java
@@ -1,8 +1,5 @@
 package trible.histour.application.domain.quiz;
 
 public enum QuizType {
-	KEYWORD,
-	PHOTO,
-	VOICE,
-	BUTTON,
+	KEYWORD, PHOTO, VOICE
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizType.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizType.java
@@ -1,5 +1,8 @@
 package trible.histour.application.domain.quiz;
 
 public enum QuizType {
-	KEYWORD, PHOTO, VOICE
+	KEYWORD,
+	PHOTO,
+	VOICE,
+	BUTTON,
 }

--- a/histour-application/src/main/java/trible/histour/application/port/input/CharacterUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/CharacterUseCase.java
@@ -1,6 +1,6 @@
 package trible.histour.application.port.input;
 
-import trible.histour.application.port.input.dto.response.CharactersResponse;
+import trible.histour.application.port.input.dto.response.character.CharactersResponse;
 
 public interface CharacterUseCase {
 	CharactersResponse getCharacters();

--- a/histour-application/src/main/java/trible/histour/application/port/input/MemberUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/MemberUseCase.java
@@ -1,5 +1,5 @@
 package trible.histour.application.port.input;
 
 public interface MemberUseCase {
-	void registerProfile();
+	void updateCharacter(long memberId, long characterId);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/input/MissionUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/MissionUseCase.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.input;
+
+import trible.histour.application.port.input.dto.response.mission.MissionsResponse;
+
+public interface MissionUseCase {
+	MissionsResponse getMissions(long memberId, long placeId);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/PlaceUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/PlaceUseCase.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.input;
+
+import trible.histour.application.port.input.dto.response.place.PlacesResponse;
+
+public interface PlaceUseCase {
+	PlacesResponse getPlaces(long memberId);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/QuizUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/QuizUseCase.java
@@ -3,5 +3,5 @@ package trible.histour.application.port.input;
 import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
 
 public interface QuizUseCase {
-	QuizzesResponse getQuizzes(long missionId);
+	QuizzesResponse getQuizzes(long memberId, long missionId);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/input/QuizUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/QuizUseCase.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.input;
+
+import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
+
+public interface QuizUseCase {
+	QuizzesResponse getQuizzes(long missionId);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/request/member/CharacterUpdateRequest.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/request/member/CharacterUpdateRequest.java
@@ -1,0 +1,10 @@
+package trible.histour.application.port.input.dto.request.member;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "캐릭터 설정 요청 정보")
+public record CharacterUpdateRequest(
+	@Schema(description = "설정하려는 캐릭터 id", example = "1")
+	long characterId
+) {
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/character/CharactersResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/character/CharactersResponse.java
@@ -1,4 +1,4 @@
-package trible.histour.application.port.input.dto.response;
+package trible.histour.application.port.input.dto.response.character;
 
 import java.util.List;
 

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionResponse.java
@@ -1,0 +1,41 @@
+package trible.histour.application.port.input.dto.response.mission;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.mission.MemberMission;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.domain.mission.MissionState;
+import trible.histour.application.domain.mission.MissionType;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "미션 조회 정보 응답")
+public record MissionResponse(
+	@Schema(description = "미션 id", example = "1")
+	long id,
+	@Schema(description = "미션 상태", example = "PROGRESS")
+	MissionState state,
+	@Schema(description = "미션 이름", example = "화성행궁 - 천자의 명에 따라")
+	String name,
+	@Schema(description = "미션 타입", example = "NORMAL")
+	MissionType type,
+	@Schema(description = "수행한 퀴즈 개수", example = "3")
+	int clearedQuizCount,
+	@Schema(description = "전체 퀴즈 개수", example = "6")
+	int totalQuizCount
+) {
+
+	public static MissionResponse of(
+		Mission mission,
+		MemberMission memberMission,
+		int clearedQuizCount,
+		int totalQuizCount
+	) {
+		return MissionResponse.builder()
+			.id(mission.getId())
+			.state(memberMission.getState())
+			.clearedQuizCount(clearedQuizCount)
+			.totalQuizCount(totalQuizCount)
+			.build();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionResponse.java
@@ -1,12 +1,17 @@
 package trible.histour.application.port.input.dto.response.mission;
 
+import java.util.List;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.val;
 import trible.histour.application.domain.mission.MemberMission;
 import trible.histour.application.domain.mission.Mission;
 import trible.histour.application.domain.mission.MissionState;
 import trible.histour.application.domain.mission.MissionType;
+import trible.histour.application.domain.quiz.MemberQuiz;
+import trible.histour.application.domain.quiz.Quiz;
 
 @Builder(access = AccessLevel.PRIVATE)
 @Schema(description = "미션 조회 정보 응답")
@@ -28,12 +33,18 @@ public record MissionResponse(
 	public static MissionResponse of(
 		Mission mission,
 		MemberMission memberMission,
-		int clearedQuizCount,
-		int totalQuizCount
+		List<MemberQuiz> memberQuizzes,
+		List<Quiz> quizzes
 	) {
+		val state = (memberMission == null) ? MissionState.BEFORE : memberMission.getState();
+		val clearedQuizCount = (memberQuizzes == null) ? 0 : memberQuizzes.size();
+		val totalQuizCount = (quizzes == null) ? 0 : quizzes.size();
+
 		return MissionResponse.builder()
 			.id(mission.getId())
-			.state(memberMission.getState())
+			.state(state)
+			.name(mission.getName())
+			.type(mission.getType())
 			.clearedQuizCount(clearedQuizCount)
 			.totalQuizCount(totalQuizCount)
 			.build();

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionsResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionsResponse.java
@@ -44,8 +44,8 @@ public record MissionsResponse(
 				MissionResponse.of(
 					mission,
 					memberMissionByMissionId.get(mission.getId()),
-					memberQuizzesByMissionId.get(mission.getId()).size(),
-					quizzesByMissionId.get(mission.getId()).size()))
+					memberQuizzesByMissionId.get(mission.getId()),
+					quizzesByMissionId.get(mission.getId())))
 			.toList();
 	}
 }

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionsResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/mission/MissionsResponse.java
@@ -1,0 +1,51 @@
+package trible.histour.application.port.input.dto.response.mission;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.mission.MemberMission;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.domain.place.Place;
+import trible.histour.application.domain.quiz.MemberQuiz;
+import trible.histour.application.domain.quiz.Quiz;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "미션 목록 조회 정보 응답")
+public record MissionsResponse(
+	@Schema(description = "필수 미션 수행 개수", example = "1")
+	int requiredMissionCount,
+	@Schema(description = "미션 정보 목록")
+	List<MissionResponse> missions
+) {
+
+	public static MissionsResponse of(
+		Place place,
+		List<Mission> missions,
+		Map<Long, MemberMission> memberMissionByMissionId,
+		Map<Long, List<Quiz>> quizzesByMissionId,
+		Map<Long, List<MemberQuiz>> memberQuizzesByMissionId
+	) {
+		return MissionsResponse.builder()
+			.requiredMissionCount(place.getRequiredMissionCount())
+			.missions(toMissions(missions, memberMissionByMissionId, quizzesByMissionId, memberQuizzesByMissionId))
+			.build();
+	}
+
+	private static List<MissionResponse> toMissions(
+		List<Mission> missions,
+		Map<Long, MemberMission> memberMissionByMissionId,
+		Map<Long, List<Quiz>> quizzesByMissionId,
+		Map<Long, List<MemberQuiz>> memberQuizzesByMissionId
+	) {
+		return missions.stream().map(mission ->
+				MissionResponse.of(
+					mission,
+					memberMissionByMissionId.get(mission.getId()),
+					memberQuizzesByMissionId.get(mission.getId()).size(),
+					quizzesByMissionId.get(mission.getId()).size()))
+			.toList();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/place/PlaceResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/place/PlaceResponse.java
@@ -1,0 +1,32 @@
+package trible.histour.application.port.input.dto.response.place;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.place.Place;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "장소 조회 정보 응답")
+public record PlaceResponse(
+	@Schema(description = "여행지 id", example = "1")
+	long placeId,
+	@Schema(description = "여행지 이름", example = "수원")
+	String name,
+	@Schema(description = "여행지 설명", example = "수원은 어쩌구 ...더보기")
+	String description,
+	@Schema(description = "수행한 미션 개수", example = "3")
+	int clearedMissionCount,
+	@Schema(description = "전체 미션 개수", example = "10")
+	int totalMissionCount
+) {
+
+	public static PlaceResponse of(Place place, int clearedMissionCount) {
+		return PlaceResponse.builder()
+			.placeId(place.getId())
+			.name(place.getName())
+			.description(place.getDescription())
+			.clearedMissionCount(clearedMissionCount)
+			.totalMissionCount(place.getRequiredMissionCount()) //TODO: client,plan 논의 필요
+			.build();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/place/PlacesResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/place/PlacesResponse.java
@@ -1,0 +1,40 @@
+package trible.histour.application.port.input.dto.response.place;
+
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.val;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.domain.place.Place;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "여행지 목록 조회 정보 응답")
+public record PlacesResponse(
+	@Schema(description = "여행지 정보 목록")
+	List<PlaceResponse> places
+) {
+
+	public static PlacesResponse of(
+		Map<Long, Place> placeById,
+		Map<Long, List<Mission>> missionsByPlaceId
+	) {
+		return PlacesResponse.builder()
+			.places(toPlaces(placeById, missionsByPlaceId))
+			.build();
+	}
+
+	private static List<PlaceResponse> toPlaces(
+		Map<Long, Place> placeById,
+		Map<Long, List<Mission>> missionsByPlaceId
+	) {
+		return placeById.values().stream()
+			.map(place -> {
+				val clearedMissionCount = missionsByPlaceId.getOrDefault(place.getId(), List.of()).size();
+				return PlaceResponse.of(place, clearedMissionCount);
+			})
+			.toList();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizResponse.java
@@ -1,0 +1,36 @@
+package trible.histour.application.port.input.dto.response.quiz;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.quiz.Quiz;
+import trible.histour.application.domain.quiz.QuizType;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "퀴즈 정보 응답")
+public record QuizResponse(
+	@Schema(description = "퀴즈 id", example = "1")
+	long id,
+	@Schema(description = "퀴즈 타입", example = "KEYWORD")
+	QuizType type,
+	@Schema(description = "퀴즈 힌트", example = "화성행궁의 중심")
+	String hint,
+	@Schema(description = "퀴즈 답", example = "봉수당")
+	String answer,
+	@Schema(description = "퀴즈 이미지 url", example = "https://www.test")
+	String imageUrl,
+	@Schema(description = "퀴즈 순서", example = "1")
+	int sequence
+) {
+
+	public static QuizResponse of(Quiz quiz) {
+		return QuizResponse.builder()
+			.id(quiz.getId())
+			.type(quiz.getType())
+			.hint(quiz.getHint())
+			.answer(quiz.getAnswer())
+			.imageUrl(quiz.getImageUrl())
+			.sequence(quiz.getSequence())
+			.build();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
@@ -16,17 +16,14 @@ public record QuizzesResponse(
 	String missionName,
 	@Schema(description = "미션 타입", example = "NORMAL")
 	MissionType missionType,
-	@Schema(description = "수행한 퀴즈 개수", example = "0")
-	int clearedQuizCount,
 	@Schema(description = "퀴즈 정보 목록")
 	List<QuizResponse> quizzes
 ) {
 
-	public static QuizzesResponse of(Mission mission, List<Quiz> quizzes, int clearedQuizCount) {
+	public static QuizzesResponse of(Mission mission, List<Quiz> quizzes) {
 		return QuizzesResponse.builder()
 			.missionName(mission.getName())
 			.missionType(mission.getType())
-			.clearedQuizCount(clearedQuizCount)
 			.quizzes(quizzes.stream().map(QuizResponse::of).toList())
 			.build();
 	}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
@@ -1,0 +1,30 @@
+package trible.histour.application.port.input.dto.response.quiz;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.domain.mission.MissionType;
+import trible.histour.application.domain.quiz.Quiz;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "퀴즈 조회 정보 응답")
+public record QuizzesResponse(
+	@Schema(description = "미션 이름", example = "화성행궁 - 천자의 명에 따라")
+	String missionName,
+	@Schema(description = "미션 타입", example = "NORMAL")
+	MissionType missionType,
+	@Schema(description = "퀴즈 정보 목록")
+	List<QuizResponse> quizzes
+) {
+
+	public static QuizzesResponse of(Mission mission, List<Quiz> quizzes) {
+		return QuizzesResponse.builder()
+			.missionName(mission.getName())
+			.missionType(mission.getType())
+			.quizzes(quizzes.stream().map(QuizResponse::of).toList())
+			.build();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/quiz/QuizzesResponse.java
@@ -16,14 +16,17 @@ public record QuizzesResponse(
 	String missionName,
 	@Schema(description = "미션 타입", example = "NORMAL")
 	MissionType missionType,
+	@Schema(description = "수행한 퀴즈 개수", example = "0")
+	int clearedQuizCount,
 	@Schema(description = "퀴즈 정보 목록")
 	List<QuizResponse> quizzes
 ) {
 
-	public static QuizzesResponse of(Mission mission, List<Quiz> quizzes) {
+	public static QuizzesResponse of(Mission mission, List<Quiz> quizzes, int clearedQuizCount) {
 		return QuizzesResponse.builder()
 			.missionName(mission.getName())
 			.missionType(mission.getType())
+			.clearedQuizCount(clearedQuizCount)
 			.quizzes(quizzes.stream().map(QuizResponse::of).toList())
 			.build();
 	}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberMissionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberMissionPort.java
@@ -8,4 +8,6 @@ public interface MemberMissionPort {
 	List<MemberMission> findAllByMemberIdAndMissionIds(long memberId, List<Long> missionIds);
 
 	MemberMission save(MemberMission memberMission);
+
+	List<MemberMission> findAllByMemberId(long memberId);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberMissionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberMissionPort.java
@@ -1,0 +1,11 @@
+package trible.histour.application.port.output.persistence;
+
+import java.util.List;
+
+import trible.histour.application.domain.mission.MemberMission;
+
+public interface MemberMissionPort {
+	List<MemberMission> findAllByMemberIdAndMissionIds(long memberId, List<Long> missionIds);
+
+	MemberMission save(MemberMission memberMission);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberPort.java
@@ -7,4 +7,6 @@ public interface MemberPort {
 	Member signInBySocial(SocialInfo social);
 
 	void update(Member member);
+
+	Member findById(long memberId);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
@@ -1,9 +1,4 @@
 package trible.histour.application.port.output.persistence;
 
-import java.util.List;
-
-import trible.histour.application.domain.quiz.MemberQuiz;
-
 public interface MemberQuizPort {
-	List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
@@ -1,4 +1,9 @@
 package trible.histour.application.port.output.persistence;
 
+import java.util.List;
+
+import trible.histour.application.domain.quiz.MemberQuiz;
+
 public interface MemberQuizPort {
+	List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
@@ -1,0 +1,9 @@
+package trible.histour.application.port.output.persistence;
+
+import java.util.List;
+
+import trible.histour.application.domain.quiz.MemberQuiz;
+
+public interface MemberQuizPort {
+	List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
@@ -1,7 +1,11 @@
 package trible.histour.application.port.output.persistence;
 
+import java.util.List;
+
 import trible.histour.application.domain.mission.Mission;
 
 public interface MissionPort {
 	Mission findById(long missionId);
+
+	List<Mission> findAllByPlaceId(long placeId);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
@@ -8,4 +8,6 @@ public interface MissionPort {
 	Mission findById(long missionId);
 
 	List<Mission> findAllByPlaceId(long placeId);
+
+	List<Mission> findAllByMissionIds(List<Long> missionIds);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MissionPort.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.output.persistence;
+
+import trible.histour.application.domain.mission.Mission;
+
+public interface MissionPort {
+	Mission findById(long missionId);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/PlacePort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/PlacePort.java
@@ -1,7 +1,11 @@
 package trible.histour.application.port.output.persistence;
 
+import java.util.List;
+
 import trible.histour.application.domain.place.Place;
 
 public interface PlacePort {
 	Place findById(long placeId);
+
+	List<Place> findAll();
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/PlacePort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/PlacePort.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.output.persistence;
+
+import trible.histour.application.domain.place.Place;
+
+public interface PlacePort {
+	Place findById(long placeId);
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/QuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/QuizPort.java
@@ -6,4 +6,6 @@ import trible.histour.application.domain.quiz.Quiz;
 
 public interface QuizPort {
 	List<Quiz> findAllByMissionId(long missionId);
+
+	List<Quiz> findAllByMissionIds(List<Long> missionIds);
 }

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/QuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/QuizPort.java
@@ -1,0 +1,9 @@
+package trible.histour.application.port.output.persistence;
+
+import java.util.List;
+
+import trible.histour.application.domain.quiz.Quiz;
+
+public interface QuizPort {
+	List<Quiz> findAllByMissionId(long missionId);
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/CharacterApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/CharacterApi.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import trible.histour.application.port.input.CharacterUseCase;
-import trible.histour.application.port.input.dto.response.CharactersResponse;
+import trible.histour.application.port.input.dto.response.character.CharactersResponse;
 import trible.histour.input.http.controller.docs.CharacterApiDocs;
 import trible.histour.input.http.controller.dto.response.SuccessResponse;
 

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/MemberApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/MemberApi.java
@@ -1,0 +1,34 @@
+package trible.histour.input.http.controller;
+
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.MemberUseCase;
+import trible.histour.application.port.input.dto.request.member.CharacterUpdateRequest;
+import trible.histour.input.http.controller.docs.MemberApiDocs;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberApi implements MemberApiDocs {
+	private final MemberUseCase memberUseCase;
+
+	@ResponseStatus(HttpStatus.OK)
+	@PatchMapping("/character")
+	@Override
+	public SuccessResponse<?> updateCharacters(Principal principal, @RequestBody CharacterUpdateRequest request) {
+		val memberId = Long.parseLong(principal.getName());
+		val characterId = request.characterId();
+		memberUseCase.updateCharacter(memberId, characterId);
+		return SuccessResponse.ofEmpty();
+	}
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/MissionApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/MissionApi.java
@@ -1,0 +1,33 @@
+package trible.histour.input.http.controller;
+
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.MissionUseCase;
+import trible.histour.application.port.input.dto.response.mission.MissionsResponse;
+import trible.histour.input.http.controller.docs.MissionApiDocs;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/missions")
+public class MissionApi implements MissionApiDocs {
+	private final MissionUseCase missionUseCase;
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping("/place/{placeId}")
+	@Override
+	public SuccessResponse<MissionsResponse> getMissions(Principal principal, @PathVariable long placeId) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = missionUseCase.getMissions(memberId, placeId);
+		return SuccessResponse.of(response);
+	}
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/PlaceApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/PlaceApi.java
@@ -1,0 +1,32 @@
+package trible.histour.input.http.controller;
+
+import java.security.Principal;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.PlaceUseCase;
+import trible.histour.application.port.input.dto.response.place.PlacesResponse;
+import trible.histour.input.http.controller.docs.PlaceApiDocs;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/places")
+public class PlaceApi implements PlaceApiDocs {
+	private final PlaceUseCase placeUseCase;
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping
+	@Override
+	public SuccessResponse<PlacesResponse> getPlaces(Principal principal) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = placeUseCase.getPlaces(memberId);
+		return SuccessResponse.of(response);
+	}
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/QuizApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/QuizApi.java
@@ -1,5 +1,7 @@
 package trible.histour.input.http.controller;
 
+import java.security.Principal;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,8 +25,9 @@ public class QuizApi implements QuizApiDocs {
 	@ResponseStatus(HttpStatus.OK)
 	@GetMapping("/mission/{missionId}")
 	@Override
-	public SuccessResponse<QuizzesResponse> getQuizzes(@PathVariable long missionId) {
-		val response = quizUseCase.getQuizzes(missionId);
+	public SuccessResponse<QuizzesResponse> getQuizzes(Principal principal, @PathVariable long missionId) {
+		long memberId = Long.parseLong(principal.getName());
+		val response = quizUseCase.getQuizzes(memberId, missionId);
 		return SuccessResponse.of(response);
 	}
 }

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/QuizApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/QuizApi.java
@@ -1,0 +1,30 @@
+package trible.histour.input.http.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.QuizUseCase;
+import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
+import trible.histour.input.http.controller.docs.QuizApiDocs;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quizzes")
+public class QuizApi implements QuizApiDocs {
+	private final QuizUseCase quizUseCase;
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping("/mission/{missionId}")
+	@Override
+	public SuccessResponse<QuizzesResponse> getQuizzes(@PathVariable long missionId) {
+		val response = quizUseCase.getQuizzes(missionId);
+		return SuccessResponse.of(response);
+	}
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/CharacterApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/CharacterApiDocs.java
@@ -2,7 +2,7 @@ package trible.histour.input.http.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import trible.histour.application.port.input.dto.response.CharactersResponse;
+import trible.histour.application.port.input.dto.response.character.CharactersResponse;
 import trible.histour.input.http.controller.dto.response.SuccessResponse;
 
 @Tag(name = "Character", description = "캐릭터 관련 API")

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/MemberApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/MemberApiDocs.java
@@ -1,0 +1,36 @@
+package trible.histour.input.http.controller.docs;
+
+import java.security.Principal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import trible.histour.application.port.input.dto.request.member.CharacterUpdateRequest;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@Tag(name = "MemberApi", description = "회원 관련 api")
+public interface MemberApiDocs {
+
+	@Operation(
+		summary = "캐릭터 설정 api",
+		description = "회원의 캐릭터를 설정합니다.",
+		responses = {
+			@ApiResponse(
+				responseCode = "200",
+				description = "OK success",
+				content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+		}
+	)
+	SuccessResponse<?> updateCharacters(
+		@Parameter(hidden = true) Principal principal,
+		@RequestBody(
+			description = "캐릭터 설정 Request Body",
+			required = true,
+			content = @Content(schema = @Schema(implementation = CharacterUpdateRequest.class))
+		) CharacterUpdateRequest request
+	);
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/MissionApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/MissionApiDocs.java
@@ -1,0 +1,31 @@
+package trible.histour.input.http.controller.docs;
+
+import java.security.Principal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import trible.histour.application.port.input.dto.response.mission.MissionsResponse;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@Tag(name = "MissionApi", description = "미션 관련 api")
+public interface MissionApiDocs {
+
+	@Operation(
+		summary = "미션 목록 조회 api",
+		description = "여행지에 해당하는 미션 정보 목록을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "OK success")
+		}
+	)
+	SuccessResponse<MissionsResponse> getMissions(
+		@Parameter(hidden = true) Principal principal,
+		@Parameter(
+			description = "여행지 id",
+			required = true,
+			in = ParameterIn.PATH
+		) long placeId
+	);
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/PlaceApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/PlaceApiDocs.java
@@ -1,0 +1,25 @@
+package trible.histour.input.http.controller.docs;
+
+import java.security.Principal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import trible.histour.application.port.input.dto.response.place.PlacesResponse;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@Tag(name = "PlaceApi", description = "여행지 관련 api")
+public interface PlaceApiDocs {
+
+	@Operation(
+		summary = "여행지 목록 조회 api",
+		description = "여행지 정보 목록을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "OK success")
+		}
+	)
+	SuccessResponse<PlacesResponse> getPlaces(
+		@Parameter(hidden = true) Principal principal
+	);
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
@@ -1,5 +1,7 @@
 package trible.histour.input.http.controller.docs;
 
+import java.security.Principal;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -15,10 +17,12 @@ public interface QuizApiDocs {
 		summary = "퀴즈 조회 api",
 		description = "미션에 해당하는 퀴즈 목록을 조회합니다.",
 		responses = {
-			@ApiResponse(responseCode = "200", description = "OK success")
+			@ApiResponse(responseCode = "200", description = "OK success"),
+			@ApiResponse(responseCode = "400", description = "해당 미션 수행에 적합하지 않음")
 		}
 	)
 	SuccessResponse<QuizzesResponse> getQuizzes(
+		@Parameter(hidden = true) Principal principal,
 		@Parameter(
 			description = "미션 id",
 			required = true,

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
@@ -1,0 +1,28 @@
+package trible.histour.input.http.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import trible.histour.application.port.input.dto.response.quiz.QuizzesResponse;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@Tag(name = "QuizApi", description = "퀴즈 관련 api")
+public interface QuizApiDocs {
+
+	@Operation(
+		summary = "퀴즈 조회 api",
+		description = "미션에 해당하는 퀴즈 목록을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200", description = "OK success")
+		}
+	)
+	SuccessResponse<QuizzesResponse> getQuizzes(
+		@Parameter(
+			description = "미션 id",
+			required = true,
+			in = ParameterIn.PATH
+		) long missionId
+	);
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberAdapter.java
@@ -33,6 +33,11 @@ public class MemberAdapter implements MemberPort {
 		memberEntity.update(member);
 	}
 
+	@Override
+	public Member findById(long memberId) {
+		return find(memberId).toDomain();
+	}
+
 	private MemberEntity find(long id) {
 		return memberRepository.findById(id)
 			.orElseThrow(() -> new HistourException(ExceptionCode.NOT_FOUND, "MemberID: " + id));

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberMissionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberMissionAdapter.java
@@ -27,4 +27,10 @@ public class MemberMissionAdapter implements MemberMissionPort {
 		val memberMissionEntity = new MemberMissionEntity(memberMission);
 		return memberMissionRepository.save(memberMissionEntity).toDomain();
 	}
+
+	@Override
+	public List<MemberMission> findAllByMemberId(long memberId) {
+		return memberMissionRepository.findAllByMemberId(memberId)
+			.stream().map(MemberMissionEntity::toDomain).toList();
+	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberMissionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberMissionAdapter.java
@@ -1,0 +1,30 @@
+package trible.histour.output.postgresql.adapter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.domain.mission.MemberMission;
+import trible.histour.application.port.output.persistence.MemberMissionPort;
+import trible.histour.output.postgresql.persistence.entity.MemberMissionEntity;
+import trible.histour.output.postgresql.persistence.repository.MemberMissionRepository;
+
+@Component
+@RequiredArgsConstructor
+public class MemberMissionAdapter implements MemberMissionPort {
+	private final MemberMissionRepository memberMissionRepository;
+
+	@Override
+	public List<MemberMission> findAllByMemberIdAndMissionIds(long memberId, List<Long> missionIds) {
+		return memberMissionRepository.findByMemberIdAndMissionIdIn(memberId, missionIds)
+			.stream().map(MemberMissionEntity::toDomain).toList();
+	}
+
+	@Override
+	public MemberMission save(MemberMission memberMission) {
+		val memberMissionEntity = new MemberMissionEntity(memberMission);
+		return memberMissionRepository.save(memberMissionEntity).toDomain();
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
@@ -1,13 +1,23 @@
 package trible.histour.output.postgresql.adapter;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.quiz.MemberQuiz;
 import trible.histour.application.port.output.persistence.MemberQuizPort;
+import trible.histour.output.postgresql.persistence.entity.MemberQuizEntity;
 import trible.histour.output.postgresql.persistence.repository.MemberQuizRepository;
 
 @Component
 @RequiredArgsConstructor
 public class MemberQuizAdapter implements MemberQuizPort {
 	private final MemberQuizRepository memberQuizRepository;
+
+	@Override
+	public List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds) {
+		return memberQuizRepository.findAllByMemberIdAndQuizIdIn(memberId, quizIds).stream()
+			.map(MemberQuizEntity::toDomain).toList();
+	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
@@ -1,23 +1,13 @@
 package trible.histour.output.postgresql.adapter;
 
-import java.util.List;
-
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
-import trible.histour.application.domain.quiz.MemberQuiz;
 import trible.histour.application.port.output.persistence.MemberQuizPort;
-import trible.histour.output.postgresql.persistence.entity.MemberQuizEntity;
 import trible.histour.output.postgresql.persistence.repository.MemberQuizRepository;
 
 @Component
 @RequiredArgsConstructor
 public class MemberQuizAdapter implements MemberQuizPort {
 	private final MemberQuizRepository memberQuizRepository;
-
-	@Override
-	public List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds) {
-		return memberQuizRepository.findAllByMemberIdAndQuizIdIn(memberId, quizIds).stream()
-			.map(MemberQuizEntity::toDomain).toList();
-	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
@@ -1,0 +1,23 @@
+package trible.histour.output.postgresql.adapter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.quiz.MemberQuiz;
+import trible.histour.application.port.output.persistence.MemberQuizPort;
+import trible.histour.output.postgresql.persistence.entity.MemberQuizEntity;
+import trible.histour.output.postgresql.persistence.repository.MemberQuizRepository;
+
+@Component
+@RequiredArgsConstructor
+public class MemberQuizAdapter implements MemberQuizPort {
+	private final MemberQuizRepository memberQuizRepository;
+
+	@Override
+	public List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds) {
+		return memberQuizRepository.findAllByMemberIdAndQuizIdIn(memberId, quizIds).stream()
+			.map(MemberQuizEntity::toDomain).toList();
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
@@ -28,6 +28,11 @@ public class MissionAdapter implements MissionPort {
 			.stream().map(MissionEntity::toDomain).toList();
 	}
 
+	@Override
+	public List<Mission> findAllByMissionIds(List<Long> missionIds) {
+		return missionRepository.findAllByIdIn(missionIds).stream().map(MissionEntity::toDomain).toList();
+	}
+
 	private MissionEntity find(long id) {
 		return missionRepository.findById(id)
 			.orElseThrow(() -> new HistourException(ExceptionCode.NOT_FOUND, "Mission ID: " + id));

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
@@ -1,0 +1,27 @@
+package trible.histour.output.postgresql.adapter;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.mission.Mission;
+import trible.histour.application.port.output.persistence.MissionPort;
+import trible.histour.common.exception.ExceptionCode;
+import trible.histour.common.exception.HistourException;
+import trible.histour.output.postgresql.persistence.entity.MissionEntity;
+import trible.histour.output.postgresql.persistence.repository.MissionRepository;
+
+@Component
+@RequiredArgsConstructor
+public class MissionAdapter implements MissionPort {
+	private final MissionRepository missionRepository;
+
+	@Override
+	public Mission findById(long missionId) {
+		return find(missionId).toDomain();
+	}
+
+	private MissionEntity find(long id) {
+		return missionRepository.findById(id)
+			.orElseThrow(() -> new HistourException(ExceptionCode.NOT_FOUND, "Mission ID: " + id));
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MissionAdapter.java
@@ -1,5 +1,7 @@
 package trible.histour.output.postgresql.adapter;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,12 @@ public class MissionAdapter implements MissionPort {
 	@Override
 	public Mission findById(long missionId) {
 		return find(missionId).toDomain();
+	}
+
+	@Override
+	public List<Mission> findAllByPlaceId(long placeId) {
+		return missionRepository.findAllByPlaceId(placeId)
+			.stream().map(MissionEntity::toDomain).toList();
 	}
 
 	private MissionEntity find(long id) {

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/PlaceAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/PlaceAdapter.java
@@ -1,0 +1,27 @@
+package trible.histour.output.postgresql.adapter;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.place.Place;
+import trible.histour.application.port.output.persistence.PlacePort;
+import trible.histour.common.exception.ExceptionCode;
+import trible.histour.common.exception.HistourException;
+import trible.histour.output.postgresql.persistence.entity.PlaceEntity;
+import trible.histour.output.postgresql.persistence.repository.PlaceRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceAdapter implements PlacePort {
+	private final PlaceRepository placeRepository;
+
+	@Override
+	public Place findById(long placeId) {
+		return find(placeId).toDomain();
+	}
+
+	private PlaceEntity find(long id) {
+		return placeRepository.findById(id)
+			.orElseThrow(() -> new HistourException(ExceptionCode.NOT_FOUND, "PlaceID: " + id));
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/PlaceAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/PlaceAdapter.java
@@ -1,5 +1,7 @@
 package trible.histour.output.postgresql.adapter;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,11 @@ public class PlaceAdapter implements PlacePort {
 	@Override
 	public Place findById(long placeId) {
 		return find(placeId).toDomain();
+	}
+
+	@Override
+	public List<Place> findAll() {
+		return placeRepository.findAll().stream().map(PlaceEntity::toDomain).toList();
 	}
 
 	private PlaceEntity find(long id) {

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
@@ -17,7 +17,7 @@ public class QuizAdapter implements QuizPort {
 
 	@Override
 	public List<Quiz> findAllByMissionId(long missionId) {
-		return quizRepository.findAllByMissionIdOrderBySequence(missionId)
+		return quizRepository.findAllByMissionIdOrderBySequenceAsc(missionId)
 			.stream().map(QuizEntity::toDomain).toList();
 	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
@@ -1,0 +1,23 @@
+package trible.histour.output.postgresql.adapter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.quiz.Quiz;
+import trible.histour.application.port.output.persistence.QuizPort;
+import trible.histour.output.postgresql.persistence.entity.QuizEntity;
+import trible.histour.output.postgresql.persistence.repository.QuizRepository;
+
+@Component
+@RequiredArgsConstructor
+public class QuizAdapter implements QuizPort {
+	private final QuizRepository quizRepository;
+
+	@Override
+	public List<Quiz> findAllByMissionId(long missionId) {
+		return quizRepository.findAllByMissionIdOrderBySequence(missionId)
+			.stream().map(QuizEntity::toDomain).toList();
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/QuizAdapter.java
@@ -20,4 +20,10 @@ public class QuizAdapter implements QuizPort {
 		return quizRepository.findAllByMissionIdOrderBySequenceAsc(missionId)
 			.stream().map(QuizEntity::toDomain).toList();
 	}
+
+	@Override
+	public List<Quiz> findAllByMissionIds(List<Long> missionIds) {
+		return quizRepository.findAllByMissionIdIn(missionIds)
+			.stream().map(QuizEntity::toDomain).toList();
+	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/MemberMissionEntity.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/MemberMissionEntity.java
@@ -23,7 +23,7 @@ public class MemberMissionEntity extends BaseEntity {
 
 	public MemberMissionEntity(MemberMission memberMission) {
 		this.memberId = memberMission.getMemberId();
-		this.missionId = memberMission.getPlaceId();
+		this.missionId = memberMission.getMissionId();
 		this.state = memberMission.getState();
 	}
 
@@ -31,7 +31,7 @@ public class MemberMissionEntity extends BaseEntity {
 		return MemberMission.builder()
 			.id(getId())
 			.memberId(memberId)
-			.placeId(missionId)
+			.missionId(missionId)
 			.state(state)
 			.build();
 	}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/MemberMissionEntity.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/MemberMissionEntity.java
@@ -33,6 +33,7 @@ public class MemberMissionEntity extends BaseEntity {
 			.memberId(memberId)
 			.missionId(missionId)
 			.state(state)
+			.createdAt(getCreatedAt())
 			.build();
 	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/QuizEntity.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/entity/QuizEntity.java
@@ -19,8 +19,6 @@ public class QuizEntity extends BaseEntity {
 	@Column(nullable = false)
 	private long missionId;
 	@Column(nullable = false)
-	private String content;
-	@Column(nullable = false)
 	private String hint;
 	@Column(nullable = false)
 	private String answer;
@@ -31,7 +29,6 @@ public class QuizEntity extends BaseEntity {
 
 	public QuizEntity(Quiz quiz) {
 		this.type = quiz.getType();
-		this.content = quiz.getContent();
 		this.missionId = quiz.getMissionId();
 		this.hint = quiz.getHint();
 		this.answer = quiz.getAnswer();
@@ -43,7 +40,6 @@ public class QuizEntity extends BaseEntity {
 		return Quiz.builder()
 			.id(getId())
 			.type(type)
-			.content(content)
 			.missionId(missionId)
 			.hint(hint)
 			.answer(answer)

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberMissionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberMissionRepository.java
@@ -1,8 +1,11 @@
 package trible.histour.output.postgresql.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import trible.histour.output.postgresql.persistence.entity.MemberMissionEntity;
 
 public interface MemberMissionRepository extends JpaRepository<MemberMissionEntity, Long> {
+	List<MemberMissionEntity> findByMemberIdAndMissionIdIn(long memberId, List<Long> missionIds);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberMissionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberMissionRepository.java
@@ -8,4 +8,6 @@ import trible.histour.output.postgresql.persistence.entity.MemberMissionEntity;
 
 public interface MemberMissionRepository extends JpaRepository<MemberMissionEntity, Long> {
 	List<MemberMissionEntity> findByMemberIdAndMissionIdIn(long memberId, List<Long> missionIds);
+
+	List<MemberMissionEntity> findAllByMemberId(long memberId);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
@@ -1,8 +1,11 @@
 package trible.histour.output.postgresql.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import trible.histour.output.postgresql.persistence.entity.MemberQuizEntity;
 
 public interface MemberQuizRepository extends JpaRepository<MemberQuizEntity, Long> {
+	List<MemberQuizEntity> findAllByMemberIdAndQuizIdIn(long memberId, List<Long> ids);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import trible.histour.output.postgresql.persistence.entity.MemberQuizEntity;
 
 public interface MemberQuizRepository extends JpaRepository<MemberQuizEntity, Long> {
-	List<MemberQuizEntity> findAllByMemberIdAndQuizIdIn(long memberId, List<Long> ids);
+	List<MemberQuizEntity> findAllByMemberIdAndQuizIdIn(long memberId, List<Long> quizIds);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MissionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MissionRepository.java
@@ -1,8 +1,11 @@
 package trible.histour.output.postgresql.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import trible.histour.output.postgresql.persistence.entity.MissionEntity;
 
 public interface MissionRepository extends JpaRepository<MissionEntity, Long> {
+	List<MissionEntity> findAllByPlaceId(long placeId);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MissionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MissionRepository.java
@@ -8,4 +8,6 @@ import trible.histour.output.postgresql.persistence.entity.MissionEntity;
 
 public interface MissionRepository extends JpaRepository<MissionEntity, Long> {
 	List<MissionEntity> findAllByPlaceId(long placeId);
+
+	List<MissionEntity> findAllByIdIn(List<Long> ids);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import trible.histour.output.postgresql.persistence.entity.QuizEntity;
 
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
-	List<QuizEntity> findAllByMissionIdOrderBySequence(long missionId);
+	List<QuizEntity> findAllByMissionIdOrderBySequenceAsc(long missionId);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
@@ -8,4 +8,6 @@ import trible.histour.output.postgresql.persistence.entity.QuizEntity;
 
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
 	List<QuizEntity> findAllByMissionIdOrderBySequenceAsc(long missionId);
+
+	List<QuizEntity> findAllByMissionIdIn(List<Long> missionIds);
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/QuizRepository.java
@@ -1,8 +1,11 @@
 package trible.histour.output.postgresql.persistence.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import trible.histour.output.postgresql.persistence.entity.QuizEntity;
 
 public interface QuizRepository extends JpaRepository<QuizEntity, Long> {
+	List<QuizEntity> findAllByMissionIdOrderBySequence(long missionId);
 }


### PR DESCRIPTION
## 이슈
closed #56 

## 변경 사항
- api 추가
- Character DTO 패키지 경로 변경

<br/>

**추가 필요 로직**
- [x] 접근 가능한 미션인지 검증
  - INTRO: 달성한 적 있으면 예외
  - NORMAL: 달성한 적 있거나, 해당 장소의 INTRO 미션 달성 이력이 없으면 예외
  - FINAL: 달성한 적 있거나, 해당 장소의 requiredMissionCount(-1) 충족 못하면 예외

- [x] 예외 없이 조회하는 순간 MemberMission 추가

## 스크린샷

## 세부 사항

## 체크리스트

- [x] 빌드 성공 여부
- [x] PR 포맷 확인
- [x] PR에 대해 구체적인 설명 여부
- [x] 병합 전 ddl-auto:create 실행