### PR TITLE
feature: 추천 관광지 목록 조회 API

### DIFF
--- a/histour-application/src/main/java/trible/histour/application/domain/attraction/AttractionService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/attraction/AttractionService.java
@@ -1,9 +1,5 @@
 package trible.histour.application.domain.attraction;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,22 +17,7 @@ public class AttractionService implements AttractionUseCase {
 
 	@Override
 	public AttractionsResponse getAttractions() {
-		val attractionNumber = attractionPort.countAttraction();
-		val randomNumber = getRandomNumbersInRange(1L, attractionNumber);
-		val attractions = attractionPort.findAllByAttractionIds(randomNumber);
+		val attractions = attractionPort.findRandomAttractions();
 		return AttractionsResponse.of(attractions);
-	}
-
-	public List<Long> getRandomNumbersInRange(long min, long max) {
-		List<Long> randomNumbers = new ArrayList<>();
-		Random random = new Random();
-
-		while (randomNumbers.size() < 4) {
-			val randomNumber = min + (long) (random.nextDouble() * (max - min + 1));
-			if (!randomNumbers.contains(randomNumber)) {
-				randomNumbers.add(randomNumber);
-			}
-		}
-		return randomNumbers;
 	}
 }

--- a/histour-application/src/main/java/trible/histour/application/domain/attraction/AttractionService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/attraction/AttractionService.java
@@ -1,0 +1,42 @@
+package trible.histour.application.domain.attraction;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.AttractionUseCase;
+import trible.histour.application.port.input.dto.response.attraction.AttractionsResponse;
+import trible.histour.application.port.output.persistence.AttractionPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AttractionService implements AttractionUseCase {
+	private final AttractionPort attractionPort;
+
+	@Override
+	public AttractionsResponse getAttractions() {
+		val attractionNumber = attractionPort.countAttraction();
+		val randomNumber = getRandomNumbersInRange(1L, attractionNumber);
+		val attractions = attractionPort.findAllByAttractionIds(randomNumber);
+		return AttractionsResponse.of(attractions);
+	}
+
+	public List<Long> getRandomNumbersInRange(long min, long max) {
+		List<Long> randomNumbers = new ArrayList<>();
+		Random random = new Random();
+
+		while (randomNumbers.size() < 4) {
+			val randomNumber = min + (long) (random.nextDouble() * (max - min + 1));
+			if (!randomNumbers.contains(randomNumber)) {
+				randomNumbers.add(randomNumber);
+			}
+		}
+		return randomNumbers;
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/AttractionUseCase.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/AttractionUseCase.java
@@ -1,0 +1,7 @@
+package trible.histour.application.port.input;
+
+import trible.histour.application.port.input.dto.response.attraction.AttractionsResponse;
+
+public interface AttractionUseCase {
+	AttractionsResponse getAttractions();
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/attraction/AttractionResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/attraction/AttractionResponse.java
@@ -1,0 +1,25 @@
+package trible.histour.application.port.input.dto.response.attraction;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.attraction.Attraction;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "추천 여행지 조회 응답")
+public record AttractionResponse(
+		@Schema(description = "추천 여행지 이름", example = "가족들과 함께 가기 좋은 역사 관광")
+		String name,
+		@Schema(description = "추천 여행지 본문", example = "아름다운 건축 광화루원에 시작하는 ~")
+		String description,
+		@Schema(description = "추천 여행지 이미지", example = "url형식")
+		String imageUrl
+) {
+	public static AttractionResponse of(Attraction attraction) {
+		return AttractionResponse.builder()
+				.name(attraction.getName())
+				.description(attraction.getDescription())
+				.imageUrl(attraction.getImageUrl())
+				.build();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/input/dto/response/attraction/AttractionsResponse.java
+++ b/histour-application/src/main/java/trible/histour/application/port/input/dto/response/attraction/AttractionsResponse.java
@@ -1,0 +1,31 @@
+package trible.histour.application.port.input.dto.response.attraction;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import trible.histour.application.domain.attraction.Attraction;
+
+
+@Builder(access = AccessLevel.PRIVATE)
+@Schema(description = "추천 여행지 목록 조회 응답")
+public record AttractionsResponse(
+		@Schema(description = "추천 여행지 정보 목록")
+		List<AttractionResponse> attractions
+) {
+	public static AttractionsResponse of(
+			List<Attraction> attractions
+	) {
+		return AttractionsResponse.builder()
+				.attractions(toAttractions(attractions))
+				.build();
+	}
+
+	private static List<AttractionResponse> toAttractions(
+			List<Attraction> attractions
+	) {
+		return attractions.stream().map(AttractionResponse::of)
+						.toList();
+	}
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/AttractionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/AttractionPort.java
@@ -1,0 +1,11 @@
+package trible.histour.application.port.output.persistence;
+
+import java.util.List;
+
+import trible.histour.application.domain.attraction.Attraction;
+
+public interface AttractionPort {
+	List<Attraction> findAllByAttractionIds(List<Long> ids);
+
+	Long countAttraction();
+}

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/AttractionPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/AttractionPort.java
@@ -5,7 +5,6 @@ import java.util.List;
 import trible.histour.application.domain.attraction.Attraction;
 
 public interface AttractionPort {
-	List<Attraction> findAllByAttractionIds(List<Long> ids);
+	List<Attraction> findRandomAttractions();
 
-	Long countAttraction();
 }

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/AttractionApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/AttractionApi.java
@@ -21,7 +21,7 @@ public class AttractionApi implements AttractionApiDocs {
 	private final AttractionUseCase attractionUseCase;
 
 	@ResponseStatus(HttpStatus.OK)
-	@GetMapping()
+	@GetMapping
 	@Override
 	public SuccessResponse<AttractionsResponse> getAttractions() {
 		val response = attractionUseCase.getAttractions();

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/AttractionApi.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/AttractionApi.java
@@ -1,0 +1,31 @@
+package trible.histour.input.http.controller;
+
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import trible.histour.application.port.input.AttractionUseCase;
+import trible.histour.application.port.input.dto.response.attraction.AttractionsResponse;
+import trible.histour.input.http.controller.docs.AttractionApiDocs;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/attractions")
+public class AttractionApi implements AttractionApiDocs {
+	private final AttractionUseCase attractionUseCase;
+
+	@ResponseStatus(HttpStatus.OK)
+	@GetMapping()
+	@Override
+	public SuccessResponse<AttractionsResponse> getAttractions() {
+		val response = attractionUseCase.getAttractions();
+		return SuccessResponse.of(response);
+	}
+
+}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/AttractionApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/AttractionApiDocs.java
@@ -1,0 +1,15 @@
+package trible.histour.input.http.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import trible.histour.application.port.input.dto.response.attraction.AttractionsResponse;
+import trible.histour.input.http.controller.dto.response.SuccessResponse;
+
+@Tag(name = "AttractionApi", description = "추천 여행지 관련 api")
+public interface AttractionApiDocs {
+	@Operation(
+			summary = "캐릭터 목록 조회 api",
+			description = "깨비 캐릭터 전체 목록을 조회합니다."
+	)
+	SuccessResponse<AttractionsResponse> getAttractions();
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/AttractionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/AttractionAdapter.java
@@ -1,0 +1,26 @@
+package trible.histour.output.postgresql.adapter;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import trible.histour.application.domain.attraction.Attraction;
+import trible.histour.application.port.output.persistence.AttractionPort;
+import trible.histour.output.postgresql.persistence.entity.AttractionEntity;
+import trible.histour.output.postgresql.persistence.repository.AttractionRepository;
+
+@Component
+@RequiredArgsConstructor
+public class AttractionAdapter implements AttractionPort {
+	private final AttractionRepository attractionRepository;
+	@Override
+	public List<Attraction> findAllByAttractionIds(List<Long> ids) {
+		return attractionRepository.findAllByIdIn(ids).stream().map(AttractionEntity::toDomain).toList();
+	}
+
+	@Override
+	public Long countAttraction() {
+		return attractionRepository.countAttraction();
+	}
+}

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/AttractionAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/AttractionAdapter.java
@@ -15,12 +15,7 @@ import trible.histour.output.postgresql.persistence.repository.AttractionReposit
 public class AttractionAdapter implements AttractionPort {
 	private final AttractionRepository attractionRepository;
 	@Override
-	public List<Attraction> findAllByAttractionIds(List<Long> ids) {
-		return attractionRepository.findAllByIdIn(ids).stream().map(AttractionEntity::toDomain).toList();
-	}
-
-	@Override
-	public Long countAttraction() {
-		return attractionRepository.countAttraction();
+	public List<Attraction> findRandomAttractions() {
+		return attractionRepository.findRandomAttractions().stream().map(AttractionEntity::toDomain).toList();
 	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/AttractionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/AttractionRepository.java
@@ -3,12 +3,12 @@ package trible.histour.output.postgresql.persistence.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import trible.histour.output.postgresql.persistence.entity.AttractionEntity;
 
 
 public interface AttractionRepository extends JpaRepository<AttractionEntity, Long> {
-	List<AttractionEntity> findAllByIdIn(List<Long> ids);
-
-	Long countAttraction();
+	@Query(value = "SELECT * FROM attraction ORDER BY RANDOM() LIMIT", nativeQuery = true)
+	List<AttractionEntity> findRandomAttractions();
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/AttractionRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/AttractionRepository.java
@@ -1,0 +1,14 @@
+package trible.histour.output.postgresql.persistence.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import trible.histour.output.postgresql.persistence.entity.AttractionEntity;
+
+
+public interface AttractionRepository extends JpaRepository<AttractionEntity, Long> {
+	List<AttractionEntity> findAllByIdIn(List<Long> ids);
+
+	Long countAttraction();
+}


### PR DESCRIPTION
## 이슈
closed #64

## 변경 사항
* api 추가
## 스크린샷

## 세부 사항
* 랜덤으로 4개를 가져오는 로직에 대해서 2가지 방식을 생각했었습니다.
1. 쿼리 어노테이션을 사용하여 4개를 뽑아오는 방법
2. 직접 4개의 id값을 랜덤 생성하여 해당하는 attraction을 가져오는 방법

위의 2가지 방법에 대해서 2번의 경우 4개를 뽑아오는 과정에서 중복으로 돌아갈 수도 있지만 일단 더미 데이터를 저희 측에서 직접 넣기도 하고, 숫자가 많지 않아 mvp단에서는 괜찮지 않을까 생각했습니다. 1번의 경우가 가장 적절한 것 같은데 관련하여 yml파일을 수정해야하길래 일단 mvp단계에서는 2번을 택하자 생각했습니다. 추후 기회가 된다면 로직을 수정하도록 하겠습니다.
## 체크리스트

- [x] 빌드 성공 여부
- [x] PR 포맷 확인
- [x] PR에 대해 구체적인 설명 여부
