### PR TITLE
add: 회원 정보 조회 API 예외 추가

### DIFF
--- a/histour-application/src/main/java/trible/histour/application/domain/member/MemberService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/member/MemberService.java
@@ -9,6 +9,8 @@ import trible.histour.application.port.input.MemberUseCase;
 import trible.histour.application.port.input.dto.response.member.MemberInfoResponse;
 import trible.histour.application.port.output.persistence.CharacterPort;
 import trible.histour.application.port.output.persistence.MemberPort;
+import trible.histour.common.exception.ExceptionCode;
+import trible.histour.common.exception.HistourException;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +30,9 @@ public class MemberService implements MemberUseCase {
 	@Override
 	public MemberInfoResponse getMemberInfo(long memberId) {
 		val member = memberPort.findById(memberId);
+		if (member.getCharacterId() == null) {
+			throw new HistourException(ExceptionCode.NO_CHARACTER);
+		}
 		val character = characterPort.findById(member.getCharacterId());
 		return MemberInfoResponse.of(character, member);
 	}

--- a/histour-common/src/main/java/trible/histour/common/exception/ExceptionCode.java
+++ b/histour-common/src/main/java/trible/histour/common/exception/ExceptionCode.java
@@ -9,11 +9,13 @@ public enum ExceptionCode {
 	// 4xx
 	UNAUTHORIZED(401, "유효하지 않은 토큰"),
 	BAD_REQUEST(400, "유효하지 않은 요청"),
+	NO_CHARACTER(400, "캐릭터 설정이 필요한 회원"),
 	NOT_FOUND(404, "존재하지 않는 자원"),
 
 	// 5xx
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류"),
-	SERVICE_AVAILABLE(503, "서비스에 접근할 수 없음"),;
+	SERVICE_AVAILABLE(503, "서비스에 접근할 수 없음");
+
 	private final int statusCode;
 	private final String message;
 }

--- a/histour-common/src/main/java/trible/histour/common/exception/HistourException.java
+++ b/histour-common/src/main/java/trible/histour/common/exception/HistourException.java
@@ -6,15 +6,23 @@ public class HistourException extends RuntimeException {
 	@NotNull
 	public final int statusCode;
 	@NotNull
+	public final String exceptionCode;
+	@NotNull
 	public final String defaultMessage;
 	public final String detailMessage;
+
 	public HistourException(ExceptionCode exceptionCode) {
+		super("[" + exceptionCode + "] " + exceptionCode.getMessage());
 		this.statusCode = exceptionCode.getStatusCode();
+		this.exceptionCode = exceptionCode.name();
 		this.defaultMessage = exceptionCode.getMessage();
 		this.detailMessage = "";
 	}
+
 	public HistourException(ExceptionCode exceptionCode, String detailMessage) {
+		super("[" + exceptionCode + "] " + detailMessage);
 		this.statusCode = exceptionCode.getStatusCode();
+		this.exceptionCode = exceptionCode.name();
 		this.defaultMessage = exceptionCode.getMessage();
 		this.detailMessage = detailMessage;
 	}

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/dto/response/ExceptionResponse.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/dto/response/ExceptionResponse.java
@@ -4,21 +4,14 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import lombok.Builder;
+
+@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ExceptionResponse {
-	private final String message;
-	private final String cause;
-	private final LocalDateTime timestamp;
-
-	public ExceptionResponse(String message) {
-		this.message = message;
-		this.cause = "";
-		this.timestamp = LocalDateTime.now();
-	}
-
-	public ExceptionResponse(String message, String cause) {
-		this.message = message;
-		this.cause = cause;
-		this.timestamp = LocalDateTime.now();
-	}
+public record ExceptionResponse(
+	String code,
+	String message,
+	String cause,
+	LocalDateTime timestamp
+) {
 }

--- a/histour-input-http/src/main/java/trible/histour/input/http/web/ExceptionAdvice.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/web/ExceptionAdvice.java
@@ -1,5 +1,7 @@
 package trible.histour.input.http.web;
 
+import java.time.LocalDateTime;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,16 +28,28 @@ public class ExceptionAdvice {
 		log.error(exception.getMessage());
 		return ResponseEntity
 			.status(exception.statusCode)
-			.body(new ExceptionResponse(exception.defaultMessage, exception.detailMessage));
+			.body(
+				ExceptionResponse.builder()
+					.code(exception.exceptionCode)
+					.message(exception.defaultMessage)
+					.cause(exception.detailMessage)
+					.timestamp(LocalDateTime.now())
+					.build()
+			);
 	}
 
-	@ExceptionHandler(RuntimeException.class)
+	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ExceptionResponse> handleRuntimeException(RuntimeException exception, WebRequest webRequest) {
 		log.error(exception.getMessage());
 		hookLogger.send(LoggerRequest.error(exception, requestUri(webRequest)));
 		return ResponseEntity
 			.status(HttpStatus.INTERNAL_SERVER_ERROR)
-			.body(new ExceptionResponse(exception.getMessage()));
+			.body(
+				ExceptionResponse.builder()
+					.message("예기치 못한 에러가 발생했습니다.")
+					.timestamp(LocalDateTime.now())
+					.build()
+			);
 	}
 
 	private String requestUri(WebRequest webRequest) {

--- a/histour-input-http/src/main/java/trible/histour/input/http/web/HistourAuthenticationEntryPoint.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/web/HistourAuthenticationEntryPoint.java
@@ -1,6 +1,7 @@
 package trible.histour.input.http.web;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.val;
 import trible.histour.common.exception.ExceptionCode;
 import trible.histour.input.http.controller.dto.response.ExceptionResponse;
 
@@ -21,9 +23,9 @@ public class HistourAuthenticationEntryPoint implements AuthenticationEntryPoint
 
 	@Override
 	public void commence(
-			HttpServletRequest request,
-			HttpServletResponse response,
-			AuthenticationException authException
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
 	) throws IOException {
 		response.setCharacterEncoding("UTF-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -32,8 +34,15 @@ public class HistourAuthenticationEntryPoint implements AuthenticationEntryPoint
 	}
 
 	private ResponseEntity<ExceptionResponse> exceptionResponse() {
+		val exceptionCode = ExceptionCode.UNAUTHORIZED;
 		return ResponseEntity
-				.status(ExceptionCode.UNAUTHORIZED.getStatusCode())
-				.body(new ExceptionResponse(ExceptionCode.UNAUTHORIZED.getMessage()));
+			.status(exceptionCode.getStatusCode())
+			.body(
+				ExceptionResponse.builder()
+					.code(exceptionCode.name())
+					.message(exceptionCode.getMessage())
+					.timestamp(LocalDateTime.now())
+					.build()
+			);
 	}
 }


### PR DESCRIPTION
## 이슈
closed #91 

## 변경 사항
- Exception Response 필드를 추가했습니다. ([논의 내용 참고](https://discord.com/channels/1242020027536904202/1246210161979428915/1283089214266806306))
- 캐릭터 설정을 하지 않은 회원일 경우 예외 로직을 추가했습니다.

## 스크린샷

![image](https://github.com/user-attachments/assets/8a5716aa-3d92-4ff6-8303-4237e51f049d)


## 세부 사항

## 체크리스트

- [x] 빌드 성공 여부
- [x] PR 포맷 확인
- [x] PR에 대해 구체적인 설명 여부
