### PR TITLE
fix: 퀴즈 채점 API 수정

### DIFF
--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
@@ -48,6 +48,10 @@ public class QuizService implements QuizUseCase {
 	@Override
 	public QuizGradeResponse gradeQuiz(long memberId, QuizGradeRequest quizGradeRequest) {
 		val quiz = quizPort.findById(quizGradeRequest.quizId());
+		if (memberQuizPort.isExistByMemberIdAndQuizId(memberId, quiz.getId())) {
+			throw new HistourException(ExceptionCode.ALREADY_COMPLETE_QUIZ,
+					"MemberId: " + memberId + ", QuizId: " + quiz.getId());
+		}
 		val quizType = quiz.getType();
 		val mission = missionPort.findById(quiz.getMissionId());
 		val requiredMissionCount = placePort.findById(mission.getPlaceId()).getRequiredMissionCount();
@@ -72,7 +76,7 @@ public class QuizService implements QuizUseCase {
 		val completeMissionNumber = memberCompleteMissions.stream()
 			.filter(memberMission -> placeMissionIds.contains(memberMission.getMissionId()))
 			.count();
-		return (int)completeMissionNumber;
+		return (int)completeMissionNumber + 1;
 	}
 
 	private boolean getIsAnswerCorrect(QuizType quizType, String memberAnswer, String answer) {

--- a/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
+++ b/histour-application/src/main/java/trible/histour/application/port/output/persistence/MemberQuizPort.java
@@ -8,4 +8,6 @@ public interface MemberQuizPort {
 	List<MemberQuiz> findAllByMemberIdAndQuizIds(long memberId, List<Long> quizIds);
 
 	void save(MemberQuiz memberQuiz);
+
+	boolean isExistByMemberIdAndQuizId(long memberId, long quizId);
 }

--- a/histour-common/src/main/java/trible/histour/common/exception/ExceptionCode.java
+++ b/histour-common/src/main/java/trible/histour/common/exception/ExceptionCode.java
@@ -12,6 +12,7 @@ public enum ExceptionCode {
 	NOT_UNLOCK_MISSION(400, "해금하지 않은 미션"),
 	NO_CHARACTER(400, "캐릭터 설정이 필요한 회원"),
 	NOT_FOUND(404, "존재하지 않는 자원"),
+	ALREADY_COMPLETE_QUIZ(400, "이미 해결한 퀴즈"),
 
 	// 5xx
 	INTERNAL_SERVER_ERROR(500, "서버 내부 오류"),

--- a/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
+++ b/histour-input-http/src/main/java/trible/histour/input/http/controller/docs/QuizApiDocs.java
@@ -39,7 +39,8 @@ public interface QuizApiDocs {
 			summary = "퀴즈 채점 API",
 			description = "퀴즈를 채점합니다.",
 			responses = {
-				@ApiResponse(responseCode = "201", description = "CREATED success")
+				@ApiResponse(responseCode = "201", description = "CREATED success"),
+				@ApiResponse(responseCode = "400", description = "이미 해결한 퀴즈"),
 			}
 	)
 	SuccessResponse<QuizGradeResponse> gradeMemberQuiz(

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/adapter/MemberQuizAdapter.java
@@ -27,4 +27,9 @@ public class MemberQuizAdapter implements MemberQuizPort {
 		val memberQuizEntity = new MemberQuizEntity(memberQuiz);
 		memberQuizRepository.save(memberQuizEntity).toDomain();
 	}
+
+	@Override
+	public boolean isExistByMemberIdAndQuizId(long memberId, long quizId) {
+		return memberQuizRepository.existsByMemberIdAndQuizId(memberId, quizId);
+	}
 }

--- a/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
+++ b/histour-output-postgresql/src/main/java/trible/histour/output/postgresql/persistence/repository/MemberQuizRepository.java
@@ -10,4 +10,6 @@ public interface MemberQuizRepository extends JpaRepository<MemberQuizEntity, Lo
 	List<MemberQuizEntity> findAllByMemberIdAndQuizIdIn(long memberId, List<Long> quizIds);
 
 	void deleteByMemberId(long memberId);
+
+	boolean existsByMemberIdAndQuizId(long memberId, long quizId);
 }


### PR DESCRIPTION
## 이슈
closed #102 

## 변경 사항
* 이미 해결한 quiz의 경우 "400-이미 해결한 퀴즈입니다." 반환 로직 추가
* 서브미션 complete처리를 서브미션 선택 과정에서 하기 때문에 마지막 퀴즈에 대해 완료한 서브 미션 개수를 반환할 때 1을 추가합니다.
## 스크린샷

## 세부 사항

## 체크리스트

- [x] 빌드 성공 여부
- [x] PR 포맷 확인
- [x] PR에 대해 구체적인 설명 여부
