### PR TITLE
fix: grade api remove +1

### DIFF
--- a/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
+++ b/histour-application/src/main/java/trible/histour/application/domain/quiz/QuizService.java
@@ -76,7 +76,7 @@ public class QuizService implements QuizUseCase {
 		val completeMissionNumber = memberCompleteMissions.stream()
 			.filter(memberMission -> placeMissionIds.contains(memberMission.getMissionId()))
 			.count();
-		return (int)completeMissionNumber + 1;
+		return (int)completeMissionNumber;
 	}
 
 	private boolean getIsAnswerCorrect(QuizType quizType, String memberAnswer, String answer) {


### PR DESCRIPTION
## 이슈
closed #111 

## 변경 사항
* 채점 API에서 완료 서브 미션 +1하던 것을 클라분들이 처리해주셔서 다시 수정했습니다.
## 스크린샷

## 세부 사항

## 체크리스트

- [x] 빌드 성공 여부
- [x] PR 포맷 확인
- [x] PR에 대해 구체적인 설명 여부
